### PR TITLE
Fix Variable construction

### DIFF
--- a/src/variables.jl
+++ b/src/variables.jl
@@ -5,9 +5,8 @@ struct Variable <: Real
     value_type::DataType
 end
 
-Variable(name,subtype,value,value_type = typeof(value)) = Variable(name,subtype,value,value_type)
-Variable(name,subtype) = Variable(name,subtype,nothing,Void)
-Variable(name,args...) = Variable(name,:None,args...)
+Variable(name,subtype,value = nothing,value_type = typeof(value)) =
+                                         Variable(name,subtype,value,value_type)
 Parameter(name,args...) = Variable(name,:Parameter,args...)
 Constant(value) = Variable(:None,:Constant,value,typeof(value))
 DependentVariable(name,args...) = Variable(name,:DependentVariable,args...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,3 +27,8 @@ eqs = [Constant(0) == σ*(y-x),
        Constant(0) == x*(ρ-z)-y,
        Constant(0) == x*y - β*z]
 ns = NonlinearSystem(eqs)
+
+
+# Default values
+p = Parameter(:p, 1)
+u = DependentVariable(:u, [1])


### PR DESCRIPTION
Remove extra `Variable` constructors that were leading to incorrect construction of `Parameter` and `DependentVariable`