### PR TITLE
RFC: add expandable derivative mechanism

### DIFF
--- a/src/SciCompDSL.jl
+++ b/src/SciCompDSL.jl
@@ -1,16 +1,14 @@
 module SciCompDSL
 
 abstract type AbstractSystem end
+abstract type AbstractOperator end
 
-# Parameterize by T so that way it can be Vector{Expression} which is defined after
-struct Operation{T}
-    op::Function
-    args::Vector{T}
-end
+include("operations.jl")
 include("variables.jl")
-const Expression = Union{Variable,Operation}
 
-export Operation, Expression
+const Expression = Union{Variable,Operation,AbstractOperator}
+
+export Operation, Expression, AbstractOperator
 
 include("operators.jl")
 include("equations.jl")

--- a/src/function_registration.jl
+++ b/src/function_registration.jl
@@ -2,7 +2,14 @@ import MacroTools: splitdef, combinedef
 import IterTools: product
 
 # Literals treated as constants
-Base.convert(::Type{Expression}, n::Number) = Constant(n)
+function Base.convert(::Type{Expression}, n::Number)
+    if !(typeof(n) <: Variable)
+        return Constant(n)
+    else
+        return n
+    end
+end
+
 # Register functions and handle literals
 macro register(sig)
     splitsig = splitdef(:($sig = nothing))

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -1,0 +1,10 @@
+# Parameterize by T so that way it can be Vector{Expression} which is defined after
+struct Operation{T}
+    op::Function
+    args::Vector{T}
+end
+
+# Operations use isequal for equality since == is an Operation
+function Base.isequal(x::Operation,y::Operation)
+    x.op == y.op && all(isequal.(x.args,y.args))
+end

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -1,12 +1,41 @@
-abstract type AbstractOperator end
-
-struct Differential
+struct Differential <: AbstractOperator
     x::Variable
     order::Int
 end
 Differential(x) = Differential(x,1)
 
 function Derivative end
-Base.:*(D::Differential,x::Expression) = Operation(Derivative,Expression[x,D.x])
+Base.:*(D::Differential,x::Operation) = Operation(Derivative,Expression[x,D])
+function Base.:*(D::Differential,x::Variable)
+    if D.x === x
+        Constant(1)
+    else
+        Variable(x.name,x.subtype,x.value,x.value_type,D)
+    end
+end
 
-export Differential,Derivative,AbstractOperator
+function expand_derivatives(O::Operation)
+    if O.op == Derivative
+        @assert length(O.args) == 2
+        Derivative(O.args[1],O.args[2])
+    else
+        for i in 1:length(O.args)
+            O.args[i] = expand_derivatives(O.args[i])
+        end
+    end
+end
+
+# Don't specialize on the function here
+function Derivative(O::Operation,by::Differential)
+    diff_idxs = find(x->isequal(x,by.x),O.args)
+    @assert diff_idxs != nothing && length(diff_idxs) == 1
+    idx = first(diff_idxs)
+    Derivative(O.op,O.args,idx)
+end
+
+## Pre-defined derivatives
+function Derivative(::typeof(sin),args,idx)
+    Operation(Base.cos,args)
+end
+
+export Differential, Derivative, expand_derivatives

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -1,15 +1,23 @@
+# <: Real to make tracing easier. Maybe a bad idea?
 struct Variable <: Real
     name::Symbol
     subtype::Symbol
     value
     value_type::DataType
+    diff::Union{AbstractOperator,Void}
 end
 
 Variable(name,subtype,value = nothing,value_type = typeof(value)) =
-                                         Variable(name,subtype,value,value_type)
+                                         Variable(name,subtype,value,value_type,nothing)
 Parameter(name,args...) = Variable(name,:Parameter,args...)
 Constant(value) = Variable(:None,:Constant,value,typeof(value))
 DependentVariable(name,args...) = Variable(name,:DependentVariable,args...)
 IndependentVariable(name,args...) = Variable(name,:IndependentVariable,args...)
 
 export Variable,Parameter,Constant,DependentVariable,IndependentVariable
+
+# Variables use isequal for equality since == is an Operation
+function Base.isequal(x::Variable,y::Variable)
+    x.name == y.name && x.subtype == y.subtype && x.value == y.value &&
+    x.value_type == y.value_type && x.diff == y.diff
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,8 @@ D*x
 D*x == -σ*(y-x)
 D*y == x*(ρ-z)-y
 
+@test D*t === Constant(1)
+
 # Define a differential equation
 eqs = [D*x == σ*(y-x),
        D*y == x*(ρ-z)-y,
@@ -32,3 +34,7 @@ ns = NonlinearSystem(eqs)
 # Default values
 p = Parameter(:p, 1)
 u = DependentVariable(:u, [1])
+
+# Derivatives
+dsin = D*sin(t)
+isequal(expand_derivatives(dsin),cos(t))


### PR DESCRIPTION
This adds an expandable derivative mechanism. Basically you overload

```julia
Derivative(::typeof(f),args,idx)
```

and return an `Operation` that corresponds to the derivative of `f` by the `idx` component. Is this nice, or should it be a dispatch on `Val{idx}` to make it easier to define different derivatives for different components?

@simonbyrne @AleMorales