### PR TITLE
require variable dependence

### DIFF
--- a/src/operators.jl
+++ b/src/operators.jl
@@ -12,14 +12,18 @@ Base.:*(D::Differential,x::Operation) = Operation(Derivative,Expression[x,D])
 function Base.:*(D::Differential,x::Variable)
     if D.x === x
         return Constant(1)
-    elseif x.subtype != :DependentVariable || D.x.subtype != :IndependentVariable
-        return Constant(0)
     else
         return Variable(x.name,x.subtype,x.value,x.value_type,D)
     end
 end
 Base.:(==)(D1::Differential, D2::Differential) = D1.order == D2.order && D1.x == D2.x
 
+"""
+expand_derivatives(O::Operation,constant_vars=[:DependentVariable])
+
+Expands the derivative operation on the operation, applying the chain rule
+and symbolically transforming the operation recrusively.
+"""
 function expand_derivatives(O::Operation)
     if O.op == Derivative
         #=

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -5,15 +5,19 @@ struct Variable <: Expression
     value
     value_type::DataType
     diff::Union{AbstractOperator,Void}
+    dependents::Vector{Variable}
 end
 
-Variable(name,subtype::Symbol=:Variable,value = nothing,value_type = typeof(value)) =
-                                 Variable(name,subtype,value,value_type,nothing)
+Variable(name,subtype::Symbol=:Variable,value = nothing,
+         value_type = typeof(value);dependents = Variable[]) =
+                                 Variable(name,subtype,value,value_type,nothing,dependents)
 Variable(name,args...) = Variable(name,:Variable,args...)
 Parameter(name,args...) = Variable(name,:Parameter,args...)
 Constant(value::Number) = Variable(Symbol(value),:Constant,value,typeof(value))
 Constant(name,value,args...) = Variable(name,:Constant,value,typeof(value))
-DependentVariable(name,args...) = Variable(name,:DependentVariable,args...)
+DependentVariable(name,args...;
+                  dependents=error("A dependence must be specified for a DependentVariable")) =
+                  Variable(name,:DependentVariable,args...;dependents=dependents)
 IndependentVariable(name,args...) = Variable(name,:IndependentVariable,args...)
 JumpVariable(name,rate,args...) = Variable(name,:JumpVariable,rate,typeof(rate),args...)
 NoiseVariable(name,args...) = Variable(name,:NoiseVariable,args...)


### PR DESCRIPTION
In the current derivatives we hardcoded some behavior of independent and dependent variables, but it won't scale well. Instead what we need to do is explicitly state dependency relationships between variables. This PR explicitly does that and moves the derivatives in that direction.

However, we need to then change the macros for easy construction. Dependent variables need to have an independent variable with them, so it should probably be something like:

```julia
@DVar x(t)
@DVar u(x,t)
```

etc. (which is why dependents is a collection). @YingboMa  do you think you could finish up this PR with the macro section?