### PR TITLE
Map subtypes in `extract_elements`

### DIFF
--- a/src/systems/diffeqs/diffeqsystem.jl
+++ b/src/systems/diffeqs/diffeqsystem.jl
@@ -20,7 +20,9 @@ function DiffEqSystem(eqs; iv_name = :IndependentVariable,
                            dv_name = :DependentVariable,
                            v_name = :Variable,
                            p_name = :Parameter)
-    ivs, dvs, vs, ps = extract_elements(eqs, (iv_name, dv_name, v_name, p_name))
+    targetmap =  Dict(iv_name => iv_name, dv_name => dv_name, v_name => v_name,
+                       p_name => p_name)
+    ivs, dvs, vs, ps = extract_elements(eqs, targetmap)
     DiffEqSystem(eqs, ivs, dvs, vs, ps, iv_name, dv_name, p_name)
 end
 
@@ -28,7 +30,8 @@ function DiffEqSystem(eqs, ivs;
                       dv_name = :DependentVariable,
                       v_name = :Variable,
                       p_name = :Parameter)
-    dvs, vs, ps = extract_elements(eqs, (dv_name, v_name, p_name))
+    targetmap =  Dict(dv_name => dv_name, v_name => v_name, p_name => p_name)
+    dvs, vs, ps = extract_elements(eqs, targetmap)
     DiffEqSystem(eqs, ivs, dvs, vs, ps, ivs[1].subtype, dv_name, p_name)
 end
 

--- a/src/systems/nonlinear/nonlinear_system.jl
+++ b/src/systems/nonlinear/nonlinear_system.jl
@@ -18,8 +18,8 @@ function NonlinearSystem(eqs;
                          dv_name = :DependentVariable,
                          p_name = :Parameter)
     # Allow the use of :DependentVariable to make it seamless with DE use
-    dvs, vs, ps = extract_elements(eqs, (dv_name, v_name, p_name))
-    vs = [dvs;vs]
+    targetmap = Dict(v_name => v_name, dv_name => v_name, p_name => p_name)
+    vs, ps = extract_elements(eqs, targetmap)
     NonlinearSystem(eqs, vs, ps, [v_name,dv_name], p_name)
 end
 


### PR DESCRIPTION
Specify mapping of original subtypes to final subtypes.
Allows a default mapping for subtypes not included in `targetmap`. If `default == nothing`, subtypes not included in `targetmap` are ignored.
Update code in `DiffEqSystem` and `NonlinearSystem`.